### PR TITLE
Replace Scribe references with VolSync

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,11 +5,11 @@ layout: home
 ---
 The Backube projects:
 
-- [Scribe][scribe] - Asynchronous data
+- [VolSync][volsync] - Asynchronous data
   replication for Kubernetes CSI storage
 - [SnapScheduler][snapscheduler] - Scheduled snapshots for Kubernetes persistent volumes
 
-[scribe]: https://scribe-replication.readthedocs.io/
+[volsyc]: https://volsync.readthedocs.io/
 [snapscheduler]: https://backube.github.io/snapscheduler/
 
 ----


### PR DESCRIPTION
I was checking out BackKube after discovering VolSync to see your other projects. It looks like VolSync was renamed but this reference was missed.

**Describe what this PR does**
<!-- Provide some context for the reviewer -->
Updates references to VolSync

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
